### PR TITLE
Add link to arcanemachine's 'extras' repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ _Customize the keyboard layout_: https://github.com/arcanemachine/zmk-ergo-s-1
 
 _Download the Fusion 360 file_: https://github.com/wizarddata/Ergo-S-1/blob/main/SOURCE/ergo-s-1-oe-rev0-v1.zip
 
+_Other useful stuff (Purchase list, Printable tenting stand, etc.)_: https://github.com/arcanemachine/Ergo-S-1-Extras
+
 **What Is it?**  
 >The Ergo S-1 is a fully wireless, split ergonomic keyboard that is compatible with cherry/gateron switches and cherry/oem/dcs keycaps. It runs on the fantastic ZMK firmware.
 


### PR DESCRIPTION
This pull request adds a link to an "Extras" repo that I put together a while back.

It contains some links that may be useful to others (purchase list, tenting stand STL, etc.), and it's not very discoverable at the moment, so I'm hoping you wouldn't mind highlighting it on your repo.

Thanks again!